### PR TITLE
Corrects the import path of logrus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lg
 
 The `lg` ("log") package is a `context`-based application logger built on the Logrus package
-(https://github.com/Sirupsen/logrus). It also includes a HTTP request logging middleware, `lg.RequestLogger`.
+(https://github.com/sirupsen/logrus). It also includes a HTTP request logging middleware, `lg.RequestLogger`.
 
 See the [example](_example/main.go) for a sample program.

--- a/_example/main.go
+++ b/_example/main.go
@@ -7,10 +7,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
 	"github.com/pressly/lg"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {

--- a/context.go
+++ b/context.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/lg.go
+++ b/lg.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/middleware.go
+++ b/middleware.go
@@ -6,11 +6,11 @@ import (
 	"runtime/debug"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/go-chi/chi/middleware"
+	"github.com/sirupsen/logrus"
 )
 
-// RequestLogger is a middleware for the github.com/Sirupsen/logrus to log requests.
+// RequestLogger is a middleware for the github.com/sirupsen/logrus to log requests.
 // It is equipt to handle recovery in case of panics and record the stack trace
 // with a panic log-level.
 func RequestLogger(logger *logrus.Logger) func(next http.Handler) http.Handler {

--- a/redirect.go
+++ b/redirect.go
@@ -3,7 +3,7 @@ package lg
 import (
 	stdlog "log"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func RedirectStdlogOutput(logger *logrus.Logger) {


### PR DESCRIPTION
Logrus has updated their import path to `github.com/sirupsen/logrus`, which is normally not much of an issue for Go, but a bunch of linters are unable to associate the two correctly. This should fix that, and cause no issues for those that are up-to-date.